### PR TITLE
refactor: rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# service-mock
+# mock_s
 
 ## About
 
@@ -16,7 +16,7 @@ import (
     "testing"
     
     "github.com/stretchr/testify/assert"
-    smock "github.com/somatech1/services-mock"
+    "github.com/somatech1/mocks"
 )
 
 func TestFoo(t *testing.T) {
@@ -26,7 +26,7 @@ func TestFoo(t *testing.T) {
     // You can explicitly define the mock type
     // NewMock[example_mock.MockExampleMockMockRecorder]
     // or let the compiler infer it
-    mock := smock.NewMock(
+    mock := mocks.New(
         t,
         example_mock.NewMockExampleMock,
     )
@@ -34,7 +34,7 @@ func TestFoo(t *testing.T) {
     expectedInput := "Hello World"
     expectedOutput := "Mocked Output"
 
-    mock.Mock(&smock.MockOptions{
+    mock.Mock(&mocks.MockOptions{
         Ctx:    ctx,
         Call:   mock.Recorder().GetByString,
         Times:  1,

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/somatech1/services-mock
+module github.com/somatech1/mocks
 
 go 1.21.5
 

--- a/internal/example/mock/example.go
+++ b/internal/example/mock/example.go
@@ -13,7 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	example "github.com/somatech1/services-mock/internal/example"
+	example "github.com/somatech1/mocks/internal/example"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/service_mock.go
+++ b/service_mock.go
@@ -19,27 +19,54 @@ type (
 	FnNewClientService[T any] func(*gomock.Controller) T
 )
 
+// MockOptions provides all available options that a mocked call might have.
 type MockOptions struct {
-	Ctx                 interface{}
-	AnyTimes            bool
-	Times               int
-	Input               interface{}
-	Return              interface{}
-	Call                interface{}
-	Error               error
+	// Ctx stands for the current context that the call should receive. If
+	// it is nil, an internal default value is created.
+	Ctx interface{}
+
+	// AnyTimes is boolean flag to set that the call can be called 0 or more times.
+	AnyTimes bool
+
+	// Times represents the number of times that the call is going to be called.
+	Times int
+
+	// Input represents all the arguments that the call will receive. It can
+	// be a single argument or slice of interfaces, receiving as many argument
+	// as necessary. If omitted, all call required arguments will be created
+	// internally.
+	Input interface{}
+
+	// Return points to the successful return value of the call. It can be
+	// omitted when an error is desired.
+	Return interface{}
+
+	// Call is the call that is being mocked at the moment.
+	Call interface{}
+
+	// Error points to the error value of the call, if that is the desired
+	// behavior.
+	Error error
+
+	// SingleErrorReturned sets that the call returns only one return value,
+	// usually an error.
 	SingleErrorReturned bool
-	DoAndReturn         interface{}
+
+	// DoAndReturn declares the action to run when the call is matched.
+	// The return values from this function are returned by the mocked
+	// function.
+	DoAndReturn interface{}
 }
 
-// NewMock returns a new mock service client that can be used to mock any service
+// New returns a new mock service client that can be used to mock any service
 // client.
 //
 // The generic type R is the type of the RECORDER returned by the EXPECT method.
 // The generic type T is the type of the service client.
 //
 // Example:
-// NewMock[subscriptionv1mock.MockSubscriptionServiceClientMockRecorder](*testing.T, subscriptionv1mock.NewMockSubscriptionServiceClient)
-func NewMock[R any, T ServiceClient[R]](
+// New[subscriptionv1mock.MockSubscriptionServiceClientMockRecorder](*testing.T, subscriptionv1mock.NewMockSubscriptionServiceClient)
+func New[R any, T ServiceClient[R]](
 	t *testing.T,
 	fn FnNewClientService[T],
 ) *MockServiceClient[R, T] {
@@ -48,15 +75,15 @@ func NewMock[R any, T ServiceClient[R]](
 	}
 }
 
-// NewMockWithCtrl returns a new mock service client that can be used to mock any service
+// NewWithCtrl returns a new mock service client that can be used to mock any service
 // client.
 //
 // The generic type R is the type of the RECORDER returned by the EXPECT method.
 // The generic type T is the type of the service client.
 //
 // Example:
-// NewMockWithCtrl[subscriptionv1mock.MockSubscriptionServiceClientMockRecorder](*gomock.Controller, subscriptionv1mock.NewMockSubscriptionServiceClient)
-func NewMockWithCtrl[R any, T ServiceClient[R]](
+// NewWithCtrl[subscriptionv1mock.MockSubscriptionServiceClientMockRecorder](*gomock.Controller, subscriptionv1mock.NewMockSubscriptionServiceClient)
+func NewWithCtrl[R any, T ServiceClient[R]](
 	ctrl *gomock.Controller,
 	fn FnNewClientService[T],
 ) *MockServiceClient[R, T] {
@@ -157,8 +184,8 @@ func setupReturnValues(mockCall *gomock.Call, opts *MockOptions) {
 		mockCall.DoAndReturn(
 			opts.DoAndReturn,
 		)
-		setupTimes(mockCall, opts)
 
+		setupTimes(mockCall, opts)
 		return
 	}
 
@@ -166,16 +193,16 @@ func setupReturnValues(mockCall *gomock.Call, opts *MockOptions) {
 		mockCall.Return(
 			opts.Error,
 		)
-		setupTimes(mockCall, opts)
 
+		setupTimes(mockCall, opts)
 		return
 	}
 
 	rets := append(startReturnValues(opts), opts.Error)
-
 	mockCall.Return(
 		rets...,
 	)
+
 	setupTimes(mockCall, opts)
 }
 

--- a/service_mock_test.go
+++ b/service_mock_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/somatech1/services-mock/internal/example"
-	example_mock "github.com/somatech1/services-mock/internal/example/mock"
+	"github.com/somatech1/mocks/internal/example"
+	example_mock "github.com/somatech1/mocks/internal/example/mock"
 )
 
 func TestGetByString(t *testing.T) {
@@ -17,9 +17,9 @@ func TestGetByString(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -46,9 +46,9 @@ func TestGetByString(t *testing.T) {
 		ctx := context.TODO()
 		a := assert.New(t)
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -80,9 +80,9 @@ func TestGetByInt(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -109,9 +109,9 @@ func TestGetByInt(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -141,9 +141,9 @@ func TestGetWithVariadic(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -173,9 +173,9 @@ func TestGetWithVariadic(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -205,9 +205,9 @@ func TestSingleError(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -235,9 +235,9 @@ func TestSingleError(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -266,9 +266,9 @@ func TestWithStruct(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -295,9 +295,9 @@ func TestWithStruct(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -326,9 +326,9 @@ func TestWithDoAndReturn(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -358,9 +358,9 @@ func TestWithDoAndReturn(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -393,9 +393,9 @@ func TestAny(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -423,9 +423,9 @@ func TestAny(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)
@@ -452,9 +452,9 @@ func TestAny(t *testing.T) {
 		a := assert.New(t)
 
 		// you can explicitly define the mock type
-		// NewMock[example_mock.MockExampleMockMockRecorder]
+		// New[example_mock.MockExampleMockMockRecorder]
 		// or let the compiler infer it
-		mock := NewMock(
+		mock := New(
 			t,
 			example_mock.NewMockExampleMock,
 		)


### PR DESCRIPTION
- Renaming main API to keep a standard.

- Also improving documentation.